### PR TITLE
Update .NET Aspire to version 9.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,13 +4,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.4.2" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.4.2" />
-    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.2" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.5.0" />
+    <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.5.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.2" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.5.0" />
     <PackageVersion Include="NGitLab" Version="10.3.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
@@ -21,7 +21,7 @@
     <PackageVersion Include="Quartz" Version="3.15.0" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.15.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="9.0.4" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.5.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/src/Toman.Management.KPIAnalysis.AppHost/Toman.Management.KPIAnalysis.AppHost.csproj
+++ b/src/Toman.Management.KPIAnalysis.AppHost/Toman.Management.KPIAnalysis.AppHost.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.2" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5" />
   <PropertyGroup>
     <RootNamespace>$(RootNamespace).AppHost</RootNamespace>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Overview
This PR upgrades the .NET Aspire packages from version 9.4.2 to 9.5.0 to take advantage of the latest features and improvements in the Aspire framework.

## Changes Made

### Package Updates
- ✅ Updated `Aspire.Hosting.AppHost` from 9.4.2 to 9.5.0
- ✅ Updated `Aspire.Hosting.PostgreSQL` from 9.4.2 to 9.5.0  
- ✅ Updated `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` from 9.4.2 to 9.5.0
- ✅ Updated `Microsoft.Extensions.ServiceDiscovery` from 9.4.2 to 9.5.0
- ✅ Updated `Aspire.Hosting.Testing` from 9.4.2 to 9.5.0

### Additional Package Updates
- ✅ Updated `Microsoft.EntityFrameworkCore.Design` from 9.0.0 to 9.0.9

### SDK Updates
- ✅ Updated `Aspire.AppHost.Sdk` version from 9.4.2 to 9.5 in the AppHost project

## Files Modified
- `Directory.Packages.props` - Central package version management
- `src/Toman.Management.KPIAnalysis.AppHost/Toman.Management.KPIAnalysis.AppHost.csproj` - AppHost SDK version

## Benefits
- 🚀 Access to latest Aspire features and improvements
- 🐛 Bug fixes and performance enhancements included in version 9.5.0
- 🔧 Improved compatibility and stability

## Testing
The application should be tested to ensure all functionality works correctly with the updated Aspire packages.

Closes #32