### PR TITLE
Fix inconsistent project information in commit time analysis endpoint

### DIFF
--- a/src/Toman.Management.KPIAnalysis.ApiService/Features/GitLabMetrics/Services/CommitTimeAnalysisService.cs
+++ b/src/Toman.Management.KPIAnalysis.ApiService/Features/GitLabMetrics/Services/CommitTimeAnalysisService.cs
@@ -65,7 +65,7 @@ public sealed class CommitTimeAnalysisService : ICommitTimeAnalysisService
             .ToList();
 
         // Fetch project details to get names
-        var userProjects = await _gitLabHttpClient.GetUserProjectsAsync(userId, cancellationToken);
+        var userProjects = await _gitLabHttpClient.GetUserContributedProjectsAsync(userId, cancellationToken);
         var projectNameMap = userProjects.ToDictionary(p => p.Id, p => p.Name ?? "Unknown");
 
         // Group events by project and calculate commit counts


### PR DESCRIPTION
## Problem
The `/api/v1/{userid}/analysis/commit-time` endpoint was showing "unknown" for all project names, while `/api/v1/{userid}/metrics/mr-cycle-time` correctly displayed project names.

## Root Cause
The `CommitTimeAnalysisService` was using `GetUserProjectsAsync()` which only returns projects owned by the user. However, users can push commits to projects they contribute to but don't own (e.g., group projects, contributed repositories).

## Solution
Changed the service to use `GetUserContributedProjectsAsync()` instead, which returns all projects the user has contributed to, ensuring project names are properly resolved from the GitLab API.

## Changes
- Modified `CommitTimeAnalysisService.AnalyzeCommitTimeDistributionAsync()` to fetch contributed projects instead of owned projects

## Testing
- Build passes successfully
- Logic ensures all projects from user events will have names resolved

Fixes #79