### PR TITLE
Phase 2: Update Technical Documentation Files - Namespace Migration

### DIFF
--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -100,7 +100,7 @@ The current configuration only requires **two sections**:
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "Toman.Management.KPIAnalysis.ApiService.Features.GitLabMetrics": "Debug"
+              "Toman.Management.KPIAnalysis": "Debug"
     }
   },
   "Processing": {
@@ -533,7 +533,7 @@ Configure data export functionality:
         "Microsoft": "Warning",
         "Microsoft.AspNetCore": "Warning",
         "Microsoft.EntityFrameworkCore": "Information",
-        "Toman.Management.KPIAnalysis": "Debug"
+        "KuriousLabs.Management.KPIAnalysis": "Debug"
       }
     },
     "WriteTo": [
@@ -571,8 +571,8 @@ Configure data export functionality:
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.EntityFrameworkCore": "Warning",
       "Microsoft.EntityFrameworkCore.Database.Command": "Information",
-      "Toman.Management.KPIAnalysis.ApiService.Features.GitLabMetrics.Services": "Debug",
-      "Toman.Management.KPIAnalysis.ApiService.Features.GitLabMetrics.Infrastructure": "Information"
+      "KuriousLabs.Management.KPIAnalysis.ApiService.Features.GitLabMetrics.Services": "Debug",
+      "KuriousLabs.Management.KPIAnalysis.ApiService.Features.GitLabMetrics.Infrastructure": "Information"
     }
   }
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -157,8 +157,8 @@
 ### Logging & Telemetry
 - **Serilog** (structured logging)
 - **OpenTelemetry** (distributed tracing)
-- **Activity Source**: `Toman.Management.KPIAnalysis.GitLabMetrics`
-- **Metrics Meter**: `Toman.Management.KPIAnalysis.GitLabMetrics`
+- **Activity Source**: `KuriousLabs.Management.KPIAnalysis.GitLabMetrics`
+- **Metrics Meter**: `KuriousLabs.Management.KPIAnalysis.GitLabMetrics`
 
 ### Configuration
 - **IOptions Pattern** for strongly-typed configuration
@@ -398,7 +398,7 @@ GET /api/v1/projects/{projectId}/metrics?windowDays=30
 ```
 GitlabMetricsAnalyzer/
 ├── src/
-│   ├── Toman.Management.KPIAnalysis.ApiService/    # Main API project
+│   ├── KuriousLabs.Management.KPIAnalysis.ApiService/    # Main API project
 │   │   ├── Program.cs                               # Entry point, DI setup
 │   │   ├── appsettings.json                         # Production config
 │   │   ├── appsettings.Development.json             # Dev config
@@ -444,13 +444,13 @@ GitlabMetricsAnalyzer/
 │   │   │       │   └── ProjectMetricsService.cs               # ✅ USED
 │   │   │       └── ServiceCollectionExtensions.cs   # DI registration
 │   │   └── Migrations/                              # ❌ UNUSED (30+ files)
-│   ├── Toman.Management.KPIAnalysis.AppHost/        # Aspire AppHost
+│   ├── KuriousLabs.Management.KPIAnalysis.AppHost/        # Aspire AppHost
 │   │   └── Program.cs                               # Aspire orchestration
-│   └── Toman.Management.KPIAnalysis.ServiceDefaults/ # Aspire defaults
+│   └── KuriousLabs.Management.KPIAnalysis.ServiceDefaults/ # Aspire defaults
 │       ├── Extensions.cs                            # Telemetry, health checks
 │       └── Constants.cs                             # Resource names
 ├── test/
-│   └── Toman.Management.KPIAnalysis.Tests/          # Unit tests
+│   └── KuriousLabs.Management.KPIAnalysis.Tests/          # Unit tests
 ├── docs/                                            # Documentation
 │   ├── CURRENT_STATE.md                             # ✅ Current architecture (this file)
 │   ├── ENDPOINT_AUDIT.md                            # ✅ API endpoint audit

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -131,7 +131,7 @@ The GitLab Metrics Analyzer v1 system consists of:
 
 3. **Run Application**:
    ```bash
-   cd src/Toman.Management.KPIAnalysis.ApiService
+   cd src/KuriousLabs.Management.KPIAnalysis.ApiService
    dotnet run
    ```
 
@@ -157,7 +157,7 @@ The GitLab Metrics Analyzer v1 system consists of:
    FROM base AS final
    WORKDIR /app
    COPY --from=publish /app/publish .
-   ENTRYPOINT ["dotnet", "Toman.Management.KPIAnalysis.ApiService.dll"]
+   ENTRYPOINT ["dotnet", "KuriousLabs.Management.KPIAnalysis.ApiService.dll"]
    ```
 
 2. **Build Image**:
@@ -533,7 +533,7 @@ kubectl apply -f ingress.yaml
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Toman.Management.KPIAnalysis": "Information"
+      "KuriousLabs.Management.KPIAnalysis": "Information"
     }
   },
   "AllowedHosts": "gitlab-metrics.company.com",

--- a/docs/TESTING_COMMIT_TIME_ANALYSIS.md
+++ b/docs/TESTING_COMMIT_TIME_ANALYSIS.md
@@ -11,7 +11,7 @@ aspire run
 
 Or run the API service directly:
 ```powershell
-dotnet run --project src/Toman.Management.KPIAnalysis.ApiService
+dotnet run --project src/KuriousLabs.Management.KPIAnalysis.ApiService
 ```
 
 ### 2. Get a Valid User ID


### PR DESCRIPTION
## Phase 2: Update Technical Documentation Files

This PR implements Phase 2 of the namespace migration from "Toman" to "KuriousLabs".

### Changes Made:
- **TESTING_COMMIT_TIME_ANALYSIS.md**: Updated dotnet run command path
- **DEPLOYMENT_GUIDE.md**: Updated cd command, Docker ENTRYPOINT, and logging configuration
- **CURRENT_STATE.md**: Updated Activity Source, Metrics Meter names, and project structure diagram
- **CONFIGURATION_GUIDE.md**: Updated multiple logging configuration entries for development and production

### Related Issues:
- Closes #122
- Part of #120 (Parent issue for complete namespace migration)

### Dependencies:
- Depends on Phase 1 being merged to `refactor/namespace-change` first

### Next Steps:
After this PR is merged, Phase 3 will update build configuration files (Directory.Build.props, etc.).

**Note**: This PR now targets the `refactor/namespace-change` branch instead of `main`.